### PR TITLE
Django 4 removed the django.utils.encoding.smart_text function.

### DIFF
--- a/django_media_fixtures/management/commands/collectmedia.py
+++ b/django_media_fixtures/management/commands/collectmedia.py
@@ -4,10 +4,17 @@ from collections import OrderedDict
 from django.core.files.storage import FileSystemStorage
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management.color import no_style
-from django.utils.encoding import smart_text
 
 from django.core.files.storage import default_storage as media_storage
 from django_media_fixtures.finders import get_finders
+
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    # Django 4 removed smart_text() function.
+    def smart_text(s, **kwargs):
+        return s
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0